### PR TITLE
Add colab check

### DIFF
--- a/min_dalle/generate_image.py
+++ b/min_dalle/generate_image.py
@@ -1,6 +1,7 @@
 import os
 import json
 import numpy
+import sys
 from PIL import Image
 from typing import Tuple, List
 
@@ -48,7 +49,9 @@ def generate_image_from_text(
     image_token_count: int = 256
 ) -> Image.Image:
     model_name = 'mega' if is_mega else 'mini'
-    model_path = './pretrained/dalle_bart_{}'.format(model_name)
+    in_colab = 'google.colab' in sys.modules
+    base_path = './content' if in_colab else '.'
+    model_path = f'{base_path}/pretrained/dalle_bart_{model_name}'
     config, vocab, merges = load_dalle_bart_metadata(model_path)
     text_tokens = tokenize_text(text, config, vocab, merges)
     params_dalle_bart = load_dalle_bart_flax_params(model_path)

--- a/min_dalle/min_dalle_torch.py
+++ b/min_dalle/min_dalle_torch.py
@@ -1,3 +1,4 @@
+import sys
 import numpy
 import torch
 from torch import Tensor
@@ -103,7 +104,9 @@ def generate_image_tokens_torch(
 
 def detokenize_torch(image_tokens: numpy.ndarray) -> numpy.ndarray:
     print("detokenizing image")
-    model_path = './pretrained/vqgan'
+    in_colab = 'google.colab' in sys.modules
+    base_path = './content' if in_colab else '.'
+    model_path = f'{base_path}/pretrained/vqgan'
     params = load_vqgan_torch_params(model_path)
     detokenizer = VQGanDetokenizer()
     detokenizer.load_state_dict(params)


### PR DESCRIPTION
The notebook fails in Google Colab because it automatically saves files under `./content`. This PR adds a check for colab and prepends the correct path. 

NB: It still fails for me because I'm not using Colab Pro and I run out of RAM. 