### PR TITLE
Support pip/pip3 binary names for setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-pip install -r requirements.txt
+_pip=$(command -v pip pip3)
+
+$_pip install -r requirements.txt
 
 mkdir -p pretrained
 
@@ -9,7 +11,7 @@ git lfs install
 git clone https://huggingface.co/dalle-mini/vqgan_imagenet_f16_16384 ./pretrained/vqgan
 
 # download dalle-mini and dalle mega
-pip install wandb
+$_pip install wandb
 wandb login
 wandb artifact get --root=./pretrained/dalle_bart_mini dalle-mini/dalle-mini/mini-1:v0
 wandb artifact get --root=./pretrained/dalle_bart_mega dalle-mini/dalle-mini/mega-1-fp16:v14 


### PR DESCRIPTION
If `set -e` is merged, this will work fine.

If `set -e` is not merged, we should check for non-empty `_pip` variable