### PR TITLE
Fixed disabling of gradients in the torch code

### DIFF
--- a/min_dalle/min_dalle_torch.py
+++ b/min_dalle/min_dalle_torch.py
@@ -2,7 +2,7 @@ import numpy
 from typing import Dict
 from torch import LongTensor, FloatTensor
 import torch
-torch.no_grad()
+torch.set_grad_enabled(False)
 
 from .models.vqgan_detokenizer import VQGanDetokenizer
 from .models.dalle_bart_encoder_torch import DalleBartEncoderTorch


### PR DESCRIPTION
`torch.no_grad()` is a context manager, it should be placed over a function as a decorator or used like so:
```python
with torch.no_grad():
    #  Computations below will be done without gradients
    x = torch.sigmoid(x)
```
Simply calling `no_grad()` will not disable gradients. The correct way to disable gradients globally would be 
```Python
torch.set_grad_enabled(False)
```