### PR TITLE
Use all logical cores in Torch mode

### DIFF
--- a/min_dalle/min_dalle_torch.py
+++ b/min_dalle/min_dalle_torch.py
@@ -1,8 +1,10 @@
 import numpy
+import os
 from typing import Dict
 from torch import LongTensor, FloatTensor
 import torch
 torch.set_grad_enabled(False)
+torch.set_num_threads(os.cpu_count())
 
 from .models.vqgan_detokenizer import VQGanDetokenizer
 from .models.dalle_bart_encoder_torch import DalleBartEncoderTorch
@@ -114,4 +116,3 @@ def detokenize_torch(image_tokens: LongTensor, is_torch: bool) -> numpy.ndarray:
     image = detokenizer.forward(image_tokens).to(torch.uint8)
     del detokenizer, params
     return image.to('cpu').detach().numpy()
-    


### PR DESCRIPTION
This is a partial solution to #27 and makes sure that we use one thread per logical core when running with Torch.

To solve this on the non-Torch side, I think you would have to do [the opposite of this](https://github.com/google/jax/issues/743#issuecomment-536377029), but when I tried sending anything for `intra_op_parallelism_threads` in `XLA_FLAGS` it just made JAX segfault.