### PR TITLE
Generate multiple images from different seeds at the same time

### DIFF
--- a/image_from_text.py
+++ b/image_from_text.py
@@ -11,6 +11,7 @@ parser.add_argument('--no-mega', dest='mega', action='store_false')
 parser.set_defaults(mega=False)
 parser.add_argument('--text', type=str, default='alien life')
 parser.add_argument('--seed', type=int, default=-1)
+parser.add_argument('--num', type=int, default=1)
 parser.add_argument('--image_path', type=str, default='generated')
 parser.add_argument('--models_root', type=str, default='pretrained')
 parser.add_argument('--token_count', type=int, default=256) # for debugging
@@ -38,6 +39,7 @@ def generate_image(
     is_mega: bool,
     text: str,
     seed: int,
+    num: int,
     image_path: str,
     models_root: str,
     token_count: int
@@ -50,14 +52,18 @@ def generate_image(
         is_verbose=True
     )
 
+    if seed < 0: seed = random.randint(0, 2**31 - num)
+
     if token_count < 256:
+        # Note that this will only generate one set of image tokens regardless of 'num'
         image_tokens = model.generate_image_tokens(text, seed)
         print('image tokens', list(image_tokens.to('cpu').detach().numpy()))
     else:
-        image = model.generate_image(text, seed)
-        save_image(image, image_path)
-        print(ascii_from_image(image, size=128))
-
+        images = model.generate_image(text, range(seed, seed + num))
+        for imgnum in range(len(images)):
+            save_image(images[imgnum], '{}{}'.format(image_path, imgnum))
+            print(ascii_from_image(images[imgnum], size=64))
+            
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -66,6 +72,7 @@ if __name__ == '__main__':
         is_mega=args.mega,
         text=args.text,
         seed=args.seed,
+        num=args.num,
         image_path=args.image_path,
         models_root=args.models_root,
         token_count=args.token_count


### PR DESCRIPTION
This adds a --num option in the image gen script to generate and save multiple images from different seeds at the same time.

It modifies the min_dalle module "seed" argument correspondingly to work with both a single int and a list of ints, so it's supposed to be backwards compatible. The return is a single image or a list of images depending on the mode of the seed argument.

I needed this as the "is_reusable" option won't work if you have a meagre 10GB of VRAM on your GPU, you need to throw away the tokenizer and encoder after they were used, then keep the decoder and run with several seeds.
